### PR TITLE
Add additional sclang search locations.

### DIFF
--- a/bin/sclangpipe_app
+++ b/bin/sclangpipe_app
@@ -37,6 +37,8 @@ app = nil
 [
   `which sclang`.chomp,
   '/Applications/SuperCollider/SuperCollider.app/Contents/Resources/sclang',
+  '/Applications/SuperCollider/SuperCollider.app/Contents/MacOS/sclang',
+  '/Applications/SuperCollider.app/Contents/MacOS/sclang',
   '/Applications/SuperCollider/sclang',
 ].each do |l|
   if File.exists?(l)


### PR DESCRIPTION
The first is where 3.7.2 is installed if unpacked from the zip downloaded from the website, if you include the top-level Supercollider directory. The second is where it would be if the top-level directory is not included, and also if installed from source.