### PR TITLE
OSX: Make sure scvim class is installed in user space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   install(FILES sc/SCVim.sc
-    DESTINATION "~/Library/Application Support/SuperCollider/Extensions/scvim"
+    DESTINATION "$ENV{HOME}/Library/Application Support/SuperCollider/Extensions/scvim"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 ELSE()
   install(FILES sc/SCVim.sc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   install(FILES sc/SCVim.sc
-    DESTINATION ~/Library/Application\ Support/SuperCollider/Extensions/scvim
+    DESTINATION "~/Library/Application Support/SuperCollider/Extensions/scvim"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 ELSE()
   install(FILES sc/SCVim.sc


### PR DESCRIPTION
Previous state still installed to the system library /Library/A... for me (MacOSX Sierra)  I guess the tilda is ignored by cmake without quotes. Ideally there would be a cmake variable for userSupportDir, but unfortunately I don't know it. Sorry for being late...