### PR TITLE
Implement highlighting of evaluated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ Change it if you have installed the plugin in other location.
 * `g:sclangDispatcher`: Absolute path to the plugin **sc_dispatcher** script.
 Defaults to `"~/.vim/bundle/scvim/bin/sc_dispatcher"`.
 Change it if you have installed the plugin in other location.
+* `g:scFlash`: Highlighting of evaluated code
 
 Example `.vimrc` line for gnome-terminal users:
 
     let g:sclangTerm = "gnome-terminal -x $SHELL -ic"
+
+To enable highlighting of evaluated code:
+
+    let g:scFlash = 1
 
 If for some reason vim can't find the path to the two launch scripts
 **start_pipe** and **sc_dispatcher** you can set them manually in your .vimrc:

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -184,6 +184,14 @@ function SClang_send()
   endif
 endfunction
 
+function SClang_line()
+  " Wrapper to be able to call `SClang_send()` without calling `FlashLine()`
+  call SClang_send()
+
+  let currentline = line('.')
+  call FlashLine(currentline)
+endfunction
+
 function SClang_block()
 	let [blkstart,blkend] = FindOuterMostBlock()
 	"blkstart[0],blkend[0] call SClang_send()
@@ -193,6 +201,7 @@ function SClang_block()
 	let l:origcol = col(".")
 	exe cmd
 	call cursor(l:origline,l:origcol)
+	call FlashRegion(blkstart[0], blkend[0])
 endfunction
 
 " ========================================================================================
@@ -275,6 +284,37 @@ function! s:get_visual_selection()
   let lines[-1] = lines[-1][: col2 - (&selection == 'inclusive' ? 1 : 2)]
   let lines[0] = lines[0][col1 - 1:]
   return join(lines, "\n")
+endfunction
+
+" ========================================================================================
+
+" Compatibility
+highlight Evaluated term=reverse cterm=reverse guibg=Grey
+
+function FlashLine(line)
+  let pattern = '\%' . a:line . 'l'
+  call Flash(pattern)
+endfunction
+
+function FlashRegion(start, end)
+  let first = a:start - 1
+  let last  = a:end + 1
+  let pattern  = ''
+  let pattern .= '\%>' . first . 'l'
+  let pattern .= '\%<' . last . 'l'
+  let pattern .= '.'
+
+  call Flash(pattern)
+endfunction
+
+function Flash(pattern)
+  " Highlight the pattern (line or region) for 150ms if `scFlash` is enabled
+  if !exists('g:scFlash') | return | endif
+
+  call matchadd("Evaluated", a:pattern)
+  redraw
+  sleep 150m
+  call clearmatches()
 endfunction
 
 "custom commands (SChelp,SCdef,SClangfree)

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -311,9 +311,19 @@ function Flash(pattern)
   " Highlight the pattern (line or region) for 150ms if `scFlash` is enabled
   if !exists('g:scFlash') | return | endif
 
-  call matchadd("Evaluated", a:pattern)
+  call matchadd('Evaluated', a:pattern)
   redraw
-  sleep 150m
+
+  " timers were introduced in vim-8.0
+  if has('timers')
+    call timer_start(200, 'ClearFlash')
+  else
+    sleep 200m
+    call ClearFlash()
+  endif
+endfunction
+
+function ClearFlash(...)
   call clearmatches()
 endfunction
 

--- a/plugin/supercollider.vim
+++ b/plugin/supercollider.vim
@@ -28,11 +28,11 @@ au Filetype supercollider let b:match_words = '(:),[:],{:}'
 
 au Filetype supercollider nnoremap <buffer> <F5> :call SClang_block()<CR>
 au Filetype supercollider inoremap <buffer> <F5> :call SClang_block()<CR>a
-au Filetype supercollider vnoremap <buffer> <F5> :call SClang_send()<CR>
+au Filetype supercollider vnoremap <buffer> <F5> :call SClang_line()<CR>
 
-au Filetype supercollider vnoremap <buffer> <F6> :call SClang_send()<CR>
-au Filetype supercollider nnoremap <buffer> <F6> :call SClang_send()<CR>
-au Filetype supercollider inoremap <buffer> <F6> :call SClang_send()<CR>a
+au Filetype supercollider vnoremap <buffer> <F6> :call SClang_line()<CR>
+au Filetype supercollider nnoremap <buffer> <F6> :call SClang_line()<CR>
+au Filetype supercollider inoremap <buffer> <F6> :call SClang_line()<CR>a
 
 au Filetype supercollider nnoremap <buffer> <F12> :call SClangHardstop()<CR>
 


### PR DESCRIPTION
This is the first time I try to write vimscript **ever** so please bear with me if I did something stupid : )

This implements highlighting of evaluated code (line or block) (`term=reverse cterm=reverse` so everyone is happy! ;)
It has to be enabled with `let g:scFlash = 1` in your `.vimrc`.

It works but it looks like there's a small delay between code evaluation and highlighting..
Could it be because of [vim redrawing](https://github.com/gusano/scvim/blob/ee1d18b791cf8e19595fca57d26f611d8931d10a/ftplugin/supercollider.vim#L314-L317)?

Any hints or suggestions are more than welcome!
Please test it!

ps: the changed files have mixed indention styles so I tried my best to not mess it up, but new code uses spaces, sorry :)

Fix https://github.com/supercollider/scvim/issues/12
Fix https://github.com/sbl/scvim/issues/42