### PR TITLE
Escape `$` when sending character literals

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -150,7 +150,8 @@ function SCFormatText(text)
 	let l:text = substitute(a:text, '\', '\\\\', 'g')
 	let l:text = substitute(l:text, '"', '\\"', 'g')
 	let l:text = substitute(l:text, '`', '\\`', 'g')
-  let l:text = '"' . l:text .'"'
+	let l:text = substitute(l:text, '\$', '\\$', 'g')
+	let l:text = '"' . l:text . '"'
 
   return l:text
 endfunction

--- a/syntax/supercollider.vim
+++ b/syntax/supercollider.vim
@@ -39,10 +39,7 @@ syn match	scSymbol "\w\+:"
 
 syn region  scString start=+"+ skip=+\\\\\|\\"+ end=+"+
 
-syn match	scChar	"\$[^ ]"
-syn match	scChar	"\$\w"
-syn match	scChar	"\$\\\\"
-syn match	scChar	"\$\\\w"
+syn match	scChar	"\$\\\?."
 
 syn match scInteger	"\%(\%(\w\|[]})\"']\s*\)\@<!-\)\=\<0[xX]\x\+\%(_\x\+\)*\>"								display
 syn match scInteger	"\%(\%(\w\|[]})\"']\s*\)\@<!-\)\=\<\%(0[dD]\)\=\%(0\|[1-9]\d*\%(_\d\+\)*\)\>"						display

--- a/syntax/supercollider.vim
+++ b/syntax/supercollider.vim
@@ -39,6 +39,7 @@ syn match	scSymbol "\w\+:"
 
 syn region  scString start=+"+ skip=+\\\\\|\\"+ end=+"+
 
+syn match	scChar	"\$[^ ]"
 syn match	scChar	"\$\w"
 syn match	scChar	"\$\\\\"
 syn match	scChar	"\$\\\w"


### PR DESCRIPTION
Fix #24 
Fix #26 

```javascript
x = [ $1, $a ]
// -> [ 1, a ]
```