### PR TITLE
add options for tmux and screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,7 @@ Supported Terminal Multiplexers are 'tmux' and 'screen'. To use with scvim,
 open the multiplexer before opening vim.  
 For example:
 
-<<<<<<< HEAD
 `user@pc-555: tmux new -s sc`  
-=======
-`user@pc-555: tmux`  
->>>>>>> ec8f634b635612ccc31774dc6342877294e727d8
 `user@pc-555: vim mySCfile.scd`  
 
 Default settings for window orienation and window size can be set in

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Change it if you have installed the plugin in other location.
 * `g:scFlash`: Highlighting of evaluated code
 * `g:sclangWindowOrientation`: sets default window orientation when using
 a supported terminal multiplexer. See Multiplexer Options for more info
-* `g:sclangWindowSize`: sets default window size when using a supported 
+* `g:sclangWindowSize`: sets default window size (percentage of screen) when using a supported 
 terminal multiplexer. See Multiplexer Options for more info
 
 Example `.vimrc` line for gnome-terminal users:
@@ -131,13 +131,17 @@ Supported Terminal Multiplexers are 'tmux' and 'screen'. To use with scvim,
 open the multiplexer before opening vim.  
 For example:
 
+<<<<<<< HEAD
+`user@pc-555: tmux new -s sc`  
+=======
 `user@pc-555: tmux`  
+>>>>>>> ec8f634b635612ccc31774dc6342877294e727d8
 `user@pc-555: vim mySCfile.scd`  
 
 Default settings for window orienation and window size can be set in
 your .vimrc file. 
 
-Window orientation options are "h" for horizonatal and "v" for veritcal. 
+Window orientation options are "h" for horizontal and "v" for vertical. 
 The double quotes are required. In tmux the "h" option will give you the vim 
 window on the left and the sclang window on the right, and the "v" will give you
 the vim window on the top and the sclang window on the bottom. In screen this 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Supported Terminal Multiplexers are 'tmux' and 'screen'. To use with scvim,
 open the multiplexer before opening vim.  
 For example:
 
-`user@pc-555: tmux  
-user@pc-555: vim mySCfile.scd`  
+`user@pc-555: tmux`  
+`user@pc-555: vim mySCfile.scd`  
 
 Default settings for window orienation and window size can be set in
 your .vimrc file. 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Change it if you have installed the plugin in other location.
 Defaults to `"~/.vim/bundle/scvim/bin/sc_dispatcher"`.
 Change it if you have installed the plugin in other location.
 * `g:scFlash`: Highlighting of evaluated code
+* `g:sclangWindowOrientation`: sets default window orientation when using
+a supported terminal multiplexer. See Multiplexer Options for more info
+* `g:sclangWindowSize': sets default window size when using a supported 
+terminal multiplexer. See Multiplexer Options for more info
 
 Example `.vimrc` line for gnome-terminal users:
 
@@ -119,3 +123,53 @@ in normal/insert mode:
 * `F5` to execute a block of code scvim will attempt to find the outermost bracket
 * `F6` to execute the current line of code
 * `F12` is a hard stop
+
+Terminal Multiplexer Options
+-----
+
+Supported Terminal Multiplexers are 'tmux' and 'screen'. To use with scvim,
+open the multiplexer before opening vim. For example:
+
+user@pc-555: tmux
+user@pc-555: vim mySCfile.scd
+
+Default settings for window orienation and window size can be set in
+your .vimrc file. 
+
+Window orientation options are "h" for horizonatal and "v" for veritcal. 
+The double quotes are required. In tmux the "h" option will give you the vim 
+window on the left and the sclang window on the right, and the "v" will give you
+the vim window on the top and the sclang window on the bottom. In screen this 
+behavior is reversed. "v" gives you windows on left and right, "h" gives you 
+windows on top and bottom.
+
+The window size option for tmux is the percentage of the screen you want the
+sclang window to take up. For example: 
+
+let g:sclangWindowSize = 30
+
+The above option will cause your sclang window to take up 30% of the screen, and 
+your vim window to take up the other 70% of the screen.
+
+The window size option for screen controls the size of the vim window, not the 
+sclang window. If window orientation is "h", the size specifies the size in
+number of lines. If window orientation is "v", the units are unknown. A nice 
+size to start with for "v" is 140. 
+
+If g:sclangWindowOrientation and g:sclangWindowSize are not set in your .vimrc 
+file, they are set to the follwing defaults respectivly:
+
+tmux: "h", 30
+screen: "v", 140
+
+### Changing Multiplexor Options on SClangStart
+
+Options for the multiplexer of your choice can be set on the fly when you use the
+SClangStart command. To do so, you must use :call before SClangStart. If only one 
+argument is used you can change window orientation. If two arguments are used you
+can change window orientation and window size. For example:
+
+:call SClangStart("h", 45)
+
+The resulting windows from calling this command will depend on whether you are 
+using tmux or screen.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Change it if you have installed the plugin in other location.
 * `g:scFlash`: Highlighting of evaluated code
 * `g:sclangWindowOrientation`: sets default window orientation when using
 a supported terminal multiplexer. See Multiplexer Options for more info
-* `g:sclangWindowSize': sets default window size when using a supported 
+* `g:sclangWindowSize`: sets default window size when using a supported 
 terminal multiplexer. See Multiplexer Options for more info
 
 Example `.vimrc` line for gnome-terminal users:
@@ -128,10 +128,11 @@ Terminal Multiplexer Options
 -----
 
 Supported Terminal Multiplexers are 'tmux' and 'screen'. To use with scvim,
-open the multiplexer before opening vim. For example:
+open the multiplexer before opening vim.  
+For example:
 
-user@pc-555: tmux
-user@pc-555: vim mySCfile.scd
+`user@pc-555: tmux  
+user@pc-555: vim mySCfile.scd`  
 
 Default settings for window orienation and window size can be set in
 your .vimrc file. 
@@ -146,7 +147,7 @@ windows on top and bottom.
 The window size option for tmux is the percentage of the screen you want the
 sclang window to take up. For example: 
 
-let g:sclangWindowSize = 30
+`let g:sclangWindowSize = 30`
 
 The above option will cause your sclang window to take up 30% of the screen, and 
 your vim window to take up the other 70% of the screen.
@@ -162,14 +163,14 @@ file, they are set to the follwing defaults respectivly:
 tmux: "h", 30
 screen: "v", 140
 
-### Changing Multiplexor Options on SClangStart
+### Changing Multiplexor Options on SClangStart:
 
 Options for the multiplexer of your choice can be set on the fly when you use the
 SClangStart command. To do so, you must use :call before SClangStart. If only one 
 argument is used you can change window orientation. If two arguments are used you
 can change window orientation and window size. For example:
 
-:call SClangStart("h", 45)
+`:call SClangStart("h", 45)`
 
 The resulting windows from calling this command will depend on whether you are 
 using tmux or screen.

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -71,13 +71,23 @@ endif
 if exists("g:sclangWindowOrientation")
 	let s:sclangWindowOrientation = g:sclangWindowOrientation
 else
-	let s:sclangWindowOrientation = "v"
+	if executable("tmux")
+		let s:sclangWindowOrientation = "h"
+	endif
+	if executable("screen")
+		let s:sclangWindowOrientation = "v"
+	endif
 endif
 
-if exists("g:sclangWindowPercentage")
-	let s:sclangWindowPercentage = g:sclangWindowPercentage
+if exists("g:sclangWindowSize")
+	let s:sclangWindowSize = g:sclangWindowSize
 else
-	let s:sclangWindowPercentage = 20
+	if executable("tmux")
+		let s:sclangWindowSize = 50
+	endif
+	if executable("screen")
+		let s:sclangWindowSize = 140
+	endif
 endif
 
 " ========================================================================================
@@ -225,7 +235,7 @@ function SClangStart(...)
 	if $TERM[0:5] == "screen"
 		if executable("tmux")
 			if a:0 == 0 
-				call system("tmux split-window -" . s:sclangWindowOrientation . " -p " . s:sclangWindowPercentage . " ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l")
+				call system("tmux split-window -" . s:sclangWindowOrientation . " -p " . s:sclangWindowSize . " ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l")
 			endif
 			if a:0 == 1 
 				call system("tmux split-window -" . a:1 . " -p 20 ; tmux send-keys " . s:sclangPipeApp . " Enter ; tmux lelect-pane -l")
@@ -235,14 +245,20 @@ function SClangStart(...)
 			endif
 			let s:sclangStarted = 1
 		else
-			echo "Sorry, tmux is not supported yet.."
+			echo "Sorry, something went wrong..."
 		endif
 		if executable("screen")
 			if a:0 == 0
 				let b:screenName = system("echo -n $STY")
-				call system("screen -S " . b:screenName . " -X eval split focus screen focus")
+				if s:sclangWindowOrientation == "h"
+					call system("screen -S " . b:screenName . " -X split")
+				endif
+				if s:sclangWindowOrientation == "v"
+					call system("screen -S " . b:screenName . " -X split -v")
+				endif
+				call system("screen -S " . b:screenName . " -X eval focus screen focus")
 				call system("screen -S " . b:screenName . " -X at 1# exec " . s:sclangPipeApp)
-
+				call system("screen -S " . b:screenName . " -X resize " . s:sclangWindowSize)
 			endif
 			if a:0 == 1
 				if a:1 == "h"
@@ -271,6 +287,8 @@ function SClangStart(...)
 			endif
 			call system("screen -S " . b:screenName . " -X bindkey -k k5 ")
 			let s:sclangStarted = 1
+		else
+			echo "Sorry, something went wrong..."
 		endif
 	else
 		call system(s:sclangTerm . " " . s:sclangPipeApp . "&")


### PR DESCRIPTION
Addresses #32.  Add options for using tmux and screen. Can set default variables for window orientation and window size in .vimrc and/or set them on the fly using :call SClangStart([options]). Updated readme with detailed instructions.