### PR TITLE
add scdoc syntax highlighting

### DIFF
--- a/plugin/supercollider.vim
+++ b/plugin/supercollider.vim
@@ -11,6 +11,9 @@ au BufEnter,BufWinEnter,BufNewFile,BufRead *.sc,*.scd runtime ftplugin/supercoll
 au BufEnter,BufWinEnter,BufNewFile,BufRead *.sc,*.scd runtime indent/sc_indent.vim
 au BufEnter,BufWinEnter,BufNewFile,BufRead *.sc,*.scd let &iskeyword="@,48-57,_,192-255"
 
+au BufEnter,BufWinEnter,BufNewFile,BufRead *.schelp set filetype=scdoc
+au BufEnter,BufWinEnter,BufNewFile,BufRead *.schelp runtime syntax/scdoc.vim
+
 " set this via EXPORT ... if you want to change it
 if exists($SCVIM_TAGFILE)
   let s:sclangTagsFile = $SCVIM_TAGFILE

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -70,6 +70,7 @@ syn match scdocDiscussion /\<discussion::/
 " modal tags
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
+" TODO: link and image highlighting based on #-separators
 syn region scdocStrong matchgroup=scdocSimpleTag start=/\<strong::/ skip=/\\::/ end=/::/
 syn region scdocEmphasis matchgroup=scdocSimpleTag start=/\<emphasis::/ skip=/\\::/ end=/::/
 syn region scdocSoft matchgroup=scdocSimpleTag start=/\<soft::/ skip=/\\::/ end=/::/

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -115,19 +115,31 @@ syn match scdocBullet /#\@<!##/ contained
 syn match scdocColumnSep /|\@<!||/ contained
 
 syn region scdocTable matchgroup=scdocSimpleTag
-            \ start=/\<Table::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet,scdocColumnSep
+            \ start=/\<Table::/ skip=/\\::/ end=/::/
+            \ contains=@SCDocModalTag,scdocBullet,scdocColumnSep,@SCDocStructure
 
 syn region scdocDefinitionList matchgroup=scdocSimpleTag
-            \ start=/\<DefinitionList::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet,scdocColumnSep
+            \ start=/\<DefinitionList::/ skip=/\\::/ end=/::/
+            \ contains=@SCDocModalTag,scdocBullet,scdocColumnSep,@SCDocStructure
 
 syn region scdocList matchgroup=scdocSimpleTag
-            \ start=/\<List::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
+            \ start=/\<List::/ skip=/\\::/ end=/::/
+            \ contains=@SCDocModalTag,scdocBullet,@SCDocStructure
 
 syn region scdocNumberedList matchgroup=scdocSimpleTag
-            \ start=/\<NumberedList::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
+            \ start=/\<NumberedList::/ skip=/\\::/ end=/::/
+            \ contains=@SCDocModalTag,scdocBullet,@SCDocStructure
 
 syn region scdocTree matchgroup=scdocSimpleTag
-            \ start=/\<Tree::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
+            \ start=/\<Tree::/ skip=/\\::/ end=/::/
+            \ contains=@SCDocModalTag,scdocBullet,@SCDocStructure
+
+syn cluster SCDocStructure contains=
+            \scdocTree,
+            \scdocList,
+            \scdocTable,
+            \scdocDefinitionList,
+            \scdocNumberedList
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " other tags

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -85,8 +85,8 @@ syn region scdocTeletype oneline matchgroup=scdocSimpleTag start=/\<teletype::/ 
 " code (see :syn-include)
 " keepend needed to avoid :: being matched as supercollider code
 syn include @SCCode syntax/supercollider.vim
-syn region scdocCode keepend matchgroup=scdocSimpleTag start=/\<code::/rs=e end=/^::/ contains=@SCCode
-syn region scdocCode oneline keepend matchgroup=scdocSimpleTag start=/\<code::/rs=e skip=/\\::/ end=/::/ contains=@SCCode
+syn region scdocCode keepend matchgroup=scdocSimpleTag start=/\<code::/ end=/^::/ contains=@SCCode
+syn region scdocCode oneline keepend matchgroup=scdocSimpleTag start=/\<code::/ skip=/\\::/ end=/::/ contains=@SCCode
 
 " TODO: table, definitionlist, list, numberedlist, tree, note, warning, footnote
 

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -24,7 +24,7 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-setlocal iskeyword=a-z,A-Z,48-57,:,_
+setlocal iskeyword=a-z,A-Z,48-57,_
 
 syn case ignore
 
@@ -33,59 +33,59 @@ syn case ignore
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " TODO: highlighting of remainder of lines?
-syn keyword scdocTitle title::
-syn keyword scdocCategories categories::
-syn keyword scdocRelated related::
-syn keyword scdocSummary summary::
-syn keyword scdocRedirect redirect::
+syn match scdocTitle /\<title::/
+syn match scdocCategories /\<categories::/
+syn match scdocRelated /\<related::/
+syn match scdocSummary /\<summary::/
+syn match scdocRedirect /\<redirect::/
 
 " deprecated
-syn keyword scdocClass class::
+syn match scdocClass /\<class::/
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " section tags
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " TODO: intelligent highlighting?
-syn keyword scdocSection section::
-syn keyword scdocDescription description::
-syn keyword scdocClassmethods classmethods::
-syn keyword scdocInstancemethods instancemethods::
-syn keyword scdocExamples examples::
-syn keyword scdocSubsection subsection::
+syn match scdocSection /\<section::/
+syn match scdocDescription /\<description::/
+syn match scdocClassmethods /\<classmethods::/
+syn match scdocInstancemethods /\<instancemethods::/
+syn match scdocExamples /\<examples::/
+syn match scdocSubsection /\<subsection::/
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " method tags
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " TODO: intelligent highlighting
-syn keyword scdocMethod method::
-syn keyword scdocPrivate private::
-syn keyword scdocCopymethod copymethod::
-syn keyword scdocArgument argument::
-syn keyword scdocReturns returns::
-syn keyword scdocDiscussion discussion::
+syn match scdocMethod /\<method::/
+syn match scdocPrivate /\<private::/
+syn match scdocCopymethod /\<copymethod::/
+syn match scdocArgument /\<argument::/
+syn match scdocReturns /\<returns::/
+syn match scdocDiscussion /\<discussion::/
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " modal tags
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-syn region scdocStrong matchgroup=scdocSimpleTag start="strong::" skip="\\::" end="::"
-syn region scdocEmphasis matchgroup=scdocSimpleTag start="emphasis::" skip="\\::" end="::"
-syn region scdocSoft matchgroup=scdocSimpleTag start="soft::" skip="\\::" end="::"
-syn region scdocLink matchgroup=scdocSimpleTag start="link::" skip="\\::" end="::"
-syn region scdocAnchor matchgroup=scdocSimpleTag start="anchor::" skip="\\::" end="::"
-syn region scdocImage matchgroup=scdocSimpleTag start="image::" skip="\\::" end="::"
+syn region scdocStrong matchgroup=scdocSimpleTag start=/\<strong::/ skip=/\\::/ end=/::/
+syn region scdocEmphasis matchgroup=scdocSimpleTag start=/\<emphasis::/ skip=/\\::/ end=/::/
+syn region scdocSoft matchgroup=scdocSimpleTag start=/\<soft::/ skip=/\\::/ end=/::/
+syn region scdocLink matchgroup=scdocSimpleTag start=/\<link::/ skip=/\\::/ end=/::/
+syn region scdocAnchor matchgroup=scdocSimpleTag start=/\<anchor::/ skip=/\\::/ end=/::/
+syn region scdocImage matchgroup=scdocSimpleTag start=/\<image::/ skip=/\\::/ end=/::/
 
 " teletype and code have inline and block forms
 " NOTE: make sure oneline version is last so it has priority!
-syn region scdocTeletype matchgroup=scdocSimpleTag start="teletype::" end="^::"
-syn region scdocTeletype oneline matchgroup=scdocSimpleTag start="teletype::" skip="\\::" end="::"
+syn region scdocTeletype matchgroup=scdocSimpleTag start=/\<teletype::/ end=/^::/
+syn region scdocTeletype oneline matchgroup=scdocSimpleTag start=/\<teletype::/ skip=/\\::/ end=/::/
 
 " code (see :syn-include)
 syn include @SCCode syntax/supercollider.vim
-syn region scdocCode matchgroup=scdocSimpleTag start="code::" end="^::" contains=@SCCode
-syn region scdocCode oneline matchgroup=scdocSimpleTag start="code::" skip="\\::" end="::" contains=@SCCode
+syn region scdocCode matchgroup=scdocSimpleTag start=/\<code::/rs=e end=/^::/ contains=@SCCode
+syn region scdocCode oneline matchgroup=scdocSimpleTag start=/\<code::/rs=e skip=/\\::/ end=/::/ contains=@SCCode
 
 " TODO: table, definitionlist, list, numberedlist, tree, note, warning, footnote
 

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -88,7 +88,10 @@ syn include @SCCode syntax/supercollider.vim
 syn region scdocCode keepend matchgroup=scdocSimpleTag start=/\<code::/ end=/^::/ contains=@SCCode
 syn region scdocCode oneline keepend matchgroup=scdocSimpleTag start=/\<code::/ skip=/\\::/ end=/::/ contains=@SCCode
 
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " notes and warnings
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
 syn cluster SCDocModalTag contains=
             \scdocStrong,
             \scdocEmphasis,
@@ -103,7 +106,10 @@ syn region scdocNote matchgroup=scdocSimpleTag start=/\<note::/ skip=/\\::/ end=
 syn region scdocWarning matchgroup=scdocSimpleTag start=/\<warning::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 syn region scdocFootnote matchgroup=scdocSimpleTag start=/\<footnote::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " lists and tables
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
 syn match scdocBullet /#\@<!##/ contained
 syn match scdocColumnSep /|\@<!||/ contained
 

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -88,7 +88,21 @@ syn include @SCCode syntax/supercollider.vim
 syn region scdocCode keepend matchgroup=scdocSimpleTag start=/\<code::/ end=/^::/ contains=@SCCode
 syn region scdocCode oneline keepend matchgroup=scdocSimpleTag start=/\<code::/ skip=/\\::/ end=/::/ contains=@SCCode
 
-" TODO: table, definitionlist, list, numberedlist, tree, note, warning, footnote
+" TODO: table, definitionlist, list, numberedlist, tree
+
+syn cluster SCDocModalTag contains=
+            \scdocStrong,
+            \scdocEmphasis,
+            \scdocSoft,
+            \scdocLink,
+            \scdocAnchor,
+            \scdocImage,
+            \scdocCode,
+            \scdocTeletype
+
+syn region scdocNote matchgroup=scdocSimpleTag start=/\<note::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
+syn region scdocWarning matchgroup=scdocSimpleTag start=/\<warning::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
+syn region scdocFootnote matchgroup=scdocSimpleTag start=/\<footnote::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 
 syn case match
 
@@ -124,6 +138,10 @@ hi def link scdocLink Underlined
 hi def link scdocAnchor Underlined
 hi def link scdocImage Underlined
 hi def link scdocTeletype Statement
+
+hi def link scdocNote String
+hi def link scdocWarning Todo
+hi def link scdocFootnote Comment
 
 hi def link scdocSimpleTag Special
 

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -88,8 +88,7 @@ syn include @SCCode syntax/supercollider.vim
 syn region scdocCode keepend matchgroup=scdocSimpleTag start=/\<code::/ end=/^::/ contains=@SCCode
 syn region scdocCode oneline keepend matchgroup=scdocSimpleTag start=/\<code::/ skip=/\\::/ end=/::/ contains=@SCCode
 
-" TODO: table, definitionlist, list, numberedlist, tree
-
+" notes and warnings
 syn cluster SCDocModalTag contains=
             \scdocStrong,
             \scdocEmphasis,
@@ -104,6 +103,7 @@ syn region scdocNote matchgroup=scdocSimpleTag start=/\<note::/ skip=/\\::/ end=
 syn region scdocWarning matchgroup=scdocSimpleTag start=/\<warning::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 syn region scdocFootnote matchgroup=scdocSimpleTag start=/\<footnote::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 
+" lists and tables
 syn match scdocBullet /#\@<!##/ contained
 syn match scdocColumnSep /|\@<!||/ contained
 

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -83,9 +83,10 @@ syn region scdocTeletype matchgroup=scdocSimpleTag start=/\<teletype::/ end=/^::
 syn region scdocTeletype oneline matchgroup=scdocSimpleTag start=/\<teletype::/ skip=/\\::/ end=/::/
 
 " code (see :syn-include)
+" keepend needed to avoid :: being matched as supercollider code
 syn include @SCCode syntax/supercollider.vim
-syn region scdocCode matchgroup=scdocSimpleTag start=/\<code::/rs=e end=/^::/ contains=@SCCode
-syn region scdocCode oneline matchgroup=scdocSimpleTag start=/\<code::/rs=e skip=/\\::/ end=/::/ contains=@SCCode
+syn region scdocCode keepend matchgroup=scdocSimpleTag start=/\<code::/rs=e end=/^::/ contains=@SCCode
+syn region scdocCode oneline keepend matchgroup=scdocSimpleTag start=/\<code::/rs=e skip=/\\::/ end=/::/ contains=@SCCode
 
 " TODO: table, definitionlist, list, numberedlist, tree, note, warning, footnote
 

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -104,6 +104,24 @@ syn region scdocNote matchgroup=scdocSimpleTag start=/\<note::/ skip=/\\::/ end=
 syn region scdocWarning matchgroup=scdocSimpleTag start=/\<warning::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 syn region scdocFootnote matchgroup=scdocSimpleTag start=/\<footnote::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag
 
+syn match scdocBullet /#\@<!##/ contained
+syn match scdocColumnSep /|\@<!||/ contained
+
+syn region scdocTable matchgroup=scdocSimpleTag
+            \ start=/\<Table::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet,scdocColumnSep
+
+syn region scdocDefinitionList matchgroup=scdocSimpleTag
+            \ start=/\<DefinitionList::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet,scdocColumnSep
+
+syn region scdocList matchgroup=scdocSimpleTag
+            \ start=/\<List::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
+
+syn region scdocNumberedList matchgroup=scdocSimpleTag
+            \ start=/\<NumberedList::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
+
+syn region scdocTree matchgroup=scdocSimpleTag
+            \ start=/\<Tree::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
+
 syn case match
 
 """""""""""""""""""""""""""""""""""""""""
@@ -144,5 +162,8 @@ hi def link scdocWarning Todo
 hi def link scdocFootnote Comment
 
 hi def link scdocSimpleTag Special
+
+hi def link scdocColumnSep PreProc
+hi def link scdocBullet PreProc
 
 let b:current_syntax = "schelp"

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -1,0 +1,129 @@
+" This file is part of SCVIM.
+"
+" SCVIM is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" SCVIM is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with SCVIM.  If not, see <http://www.gnu.org/licenses/>.
+"
+" Vim syntax file
+" Language: scdoc (SuperCollider help file markup)
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+setlocal iskeyword=a-z,A-Z,48-57,:,_
+
+syn case ignore
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" header tags
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+" TODO: highlighting of remainder of lines?
+syn keyword scdocTitle title::
+syn keyword scdocCategories categories::
+syn keyword scdocRelated related::
+syn keyword scdocSummary summary::
+syn keyword scdocRedirect redirect::
+
+" deprecated
+syn keyword scdocClass class::
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" section tags
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+" TODO: intelligent highlighting?
+syn keyword scdocSection section::
+syn keyword scdocDescription description::
+syn keyword scdocClassmethods classmethods::
+syn keyword scdocInstancemethods instancemethods::
+syn keyword scdocExamples examples::
+syn keyword scdocSubsection subsection::
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" method tags
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+" TODO: intelligent highlighting
+syn keyword scdocMethod method::
+syn keyword scdocPrivate private::
+syn keyword scdocCopymethod copymethod::
+syn keyword scdocArgument argument::
+syn keyword scdocReturns returns::
+syn keyword scdocDiscussion discussion::
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" modal tags
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+syn region scdocStrong matchgroup=scdocSimpleTag start="strong::" skip="\\::" end="::"
+syn region scdocEmphasis matchgroup=scdocSimpleTag start="emphasis::" skip="\\::" end="::"
+syn region scdocSoft matchgroup=scdocSimpleTag start="soft::" skip="\\::" end="::"
+syn region scdocLink matchgroup=scdocSimpleTag start="link::" skip="\\::" end="::"
+syn region scdocAnchor matchgroup=scdocSimpleTag start="anchor::" skip="\\::" end="::"
+syn region scdocImage matchgroup=scdocSimpleTag start="image::" skip="\\::" end="::"
+
+" teletype and code have inline and block forms
+" NOTE: make sure oneline version is last so it has priority!
+syn region scdocTeletype matchgroup=scdocSimpleTag start="teletype::" end="^::"
+syn region scdocTeletype oneline matchgroup=scdocSimpleTag start="teletype::" skip="\\::" end="::"
+
+" code (see :syn-include)
+syn include @SCCode syntax/supercollider.vim
+syn region scdocCode matchgroup=scdocSimpleTag start="code::" end="^::" contains=@SCCode
+syn region scdocCode oneline matchgroup=scdocSimpleTag start="code::" skip="\\::" end="::" contains=@SCCode
+
+" TODO: table, definitionlist, list, numberedlist, tree, note, warning, footnote
+
+syn case match
+
+"""""""""""""""""""""""""""""""""""""""""
+" linkage
+
+hi def link scdocTitle Constant
+hi def link scdocCategories Constant
+hi def link scdocRelated Constant
+hi def link scdocSummary Constant
+hi def link scdocRedirect Constant
+hi def link scdocClass Constant
+
+hi def link scdocSection Identifier
+hi def link scdocDescription Identifier
+hi def link scdocClassmethods Identifier
+hi def link scdocInstancemethods Identifier
+hi def link scdocExamples Identifier
+
+hi def link scdocSubsection Type
+
+hi def link scdocMethod Statement
+hi def link scdocPrivate Statement
+hi def link scdocCopymethod Statement
+hi def link scdocArgument Statement
+hi def link scdocReturns Statement
+hi def link scdocDiscussion Statement
+
+hi scdocStrong cterm=bold
+hi scdocEmphasis cterm=italic
+hi def link scdocSoft Comment
+hi def link scdocLink Underlined
+hi def link scdocAnchor Underlined
+hi def link scdocImage Underlined
+hi def link scdocTeletype Statement
+
+hi def link scdocSimpleTag Special
+
+let b:current_syntax = "schelp"

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -76,14 +76,14 @@ syn region scdocEmphasis matchgroup=scdocSimpleTag start=/\<emphasis::/ skip=/\\
 syn region scdocSoft matchgroup=scdocSimpleTag start=/\<soft::/ skip=/\\::/ end=/::/
 
 " only highlight the first part of the link. order is important here
-syn region scdocRealLink keepend start=/\(\<link::\)\@<=/ end=/::/he=s-1 contained
-syn region scdocRealLink keepend start=/\(\<link::\)\@<=/ end=/#/he=s-1 contained
-syn region scdocRealLink keepend start=/\(\<link::[^#]*#\)\@<=/ end=/::/he=s-1 contained
-syn region scdocRealLink keepend start=/\(\<link::[^#]*#\)\@<=/ end=/#/he=s-1 contained
+syn region scdocRealLink keepend start=// end=/::/he=s-1 contained
+syn region scdocRealLink keepend start=// end=/#/he=s-1 contained
+syn region scdocRealLink keepend start=/\(\<::[^#]*#\)\@<=/ end=/::/he=s-1 contained
+syn region scdocRealLink keepend start=/\(\<::[^#]*#\)\@<=/ end=/#/he=s-1 contained
 syn region scdocLink keepend matchgroup=scdocSimpleTag start=/\<link::/ skip=/\\::/ end=/::/ contains=scdocRealLink
 
 syn region scdocAnchor matchgroup=scdocSimpleTag start=/\<anchor::/ skip=/\\::/ end=/::/
-syn region scdocImage matchgroup=scdocSimpleTag start=/\<image::/ skip=/\\::/ end=/::/
+syn region scdocImage keepend matchgroup=scdocSimpleTag start=/\<image::/ skip=/\\::/ end=/::/ contains=scdocRealLink
 
 
 " teletype and code have inline and block forms
@@ -188,9 +188,8 @@ hi scdocStrong cterm=bold
 hi scdocEmphasis cterm=italic
 hi def link scdocSoft Comment
 hi def link scdocRealLink Underlined
-" don't link scdocLink
+" don't link scdocLink or scdocImage
 hi def link scdocAnchor Underlined
-hi def link scdocImage Underlined
 hi def link scdocTeletype Statement
 
 hi def link scdocNote String

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -122,10 +122,18 @@ syn region scdocNumberedList matchgroup=scdocSimpleTag
 syn region scdocTree matchgroup=scdocSimpleTag
             \ start=/\<Tree::/ skip=/\\::/ end=/::/ contains=@SCDocModalTag,scdocBullet
 
-syn case match
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" other tags
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-"""""""""""""""""""""""""""""""""""""""""
+syn match scdocKeyword /\<keyword::/
+syn match scdocClasstree /\<classtree::/
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " linkage
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+syn case match
 
 hi def link scdocTitle Constant
 hi def link scdocCategories Constant
@@ -165,5 +173,8 @@ hi def link scdocSimpleTag Special
 
 hi def link scdocColumnSep PreProc
 hi def link scdocBullet PreProc
+
+hi def link scdocClasstree PreProc
+hi def link scdocKeyword PreProc
 
 let b:current_syntax = "schelp"

--- a/syntax/scdoc.vim
+++ b/syntax/scdoc.vim
@@ -74,9 +74,17 @@ syn match scdocDiscussion /\<discussion::/
 syn region scdocStrong matchgroup=scdocSimpleTag start=/\<strong::/ skip=/\\::/ end=/::/
 syn region scdocEmphasis matchgroup=scdocSimpleTag start=/\<emphasis::/ skip=/\\::/ end=/::/
 syn region scdocSoft matchgroup=scdocSimpleTag start=/\<soft::/ skip=/\\::/ end=/::/
-syn region scdocLink matchgroup=scdocSimpleTag start=/\<link::/ skip=/\\::/ end=/::/
+
+" only highlight the first part of the link. order is important here
+syn region scdocRealLink keepend start=/\(\<link::\)\@<=/ end=/::/he=s-1 contained
+syn region scdocRealLink keepend start=/\(\<link::\)\@<=/ end=/#/he=s-1 contained
+syn region scdocRealLink keepend start=/\(\<link::[^#]*#\)\@<=/ end=/::/he=s-1 contained
+syn region scdocRealLink keepend start=/\(\<link::[^#]*#\)\@<=/ end=/#/he=s-1 contained
+syn region scdocLink keepend matchgroup=scdocSimpleTag start=/\<link::/ skip=/\\::/ end=/::/ contains=scdocRealLink
+
 syn region scdocAnchor matchgroup=scdocSimpleTag start=/\<anchor::/ skip=/\\::/ end=/::/
 syn region scdocImage matchgroup=scdocSimpleTag start=/\<image::/ skip=/\\::/ end=/::/
+
 
 " teletype and code have inline and block forms
 " NOTE: make sure oneline version is last so it has priority!
@@ -179,7 +187,8 @@ hi def link scdocDiscussion Statement
 hi scdocStrong cterm=bold
 hi scdocEmphasis cterm=italic
 hi def link scdocSoft Comment
-hi def link scdocLink Underlined
+hi def link scdocRealLink Underlined
+" don't link scdocLink
 hi def link scdocAnchor Underlined
 hi def link scdocImage Underlined
 hi def link scdocTeletype Statement


### PR DESCRIPTION
This PR adds highlighting for schelp files. The choices of highlighting links are totally arbitrary and open to discussion. I tried to follow the markup syntax as best I could; features include:

- highlighting for all scdoc tags
- specialized formatting for strong, emphasis, soft, link, anchor, image regions
- you get highlighting of code blocks "for free" using `syn include`
- nested trees, tables, other structures
- notes and warnings containing nested modal tags (strong::, etc) are highlighted