### PR TITLE
Add a startup script that launches VIM and SCVIM inside of a TMUX session

### DIFF
--- a/bin/scvim
+++ b/bin/scvim
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+TMUX=${TMUX:-"tmux"}
+SESSION=${SESSION:-"SuperCollider"}
+FILE=${FILE:-"$(date '+%d%m%Y').scd"}
+
+$TMUX attach-session -t $SESSION || $TMUX \
+  new-session -s $SESSION   \; \
+  send-keys -t 0 "vim $FILE -R" C-m   \; \
+  send-keys ":SClangStart" C-m   \; 


### PR DESCRIPTION
Add a startup-file script inspired by tidalvim so that it's possible to start tmux, vim and SuperCollider using just one command: scvim

see https://github.com/munshkr/vim-tidal/blob/master/bin/tidalvim for more info
