### PR TITLE
Use vim terminal instead of standalone terminal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The following variables are available for configuration in your `.vimrc` file:
 | `g:scFlash`          | Highlighting of evaluated code                                   | `0` |
 | `g:scSplitDirection` | Default window orientation when using a terminal multiplexer     | `"h"` |
 | `g:scSplitSize`      | Post window size (% of screen) when using a terminal multiplexer | `50` |
+| `g:scTerminalBuffer` | If set to `"on"` use vim's `:term` to launch `g:sclangTerm`      | `"off"` |
 
 Example `.vimrc` line for gnome-terminal users:
 

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -222,10 +222,9 @@ let s:sclangStarted = 0
 function SClangStart(...)
   let l:tmux = exists('$TMUX')
   let l:screen = exists('$STY')
+  let l:splitDir = (a:0 == 2) ? a:1 : s:scSplitDirection
+  let l:splitSize = (a:0 == 2) ? a:2 : s:scSplitSize
   if l:tmux || l:screen
-    let l:splitDir = (a:0 == 2) ? a:1 : s:scSplitDirection
-    let l:splitSize = (a:0 == 2) ? a:2 : s:scSplitSize
-
     if l:tmux
       let l:cmd = "tmux split-window -" . l:splitDir . " -p " . l:splitSize . " ;"
       let l:cmd .= "tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l"
@@ -242,9 +241,12 @@ function SClangStart(...)
       call system("screen -S " . l:screenName . " -X bindkey -k k5")
     endif
   elseif exists(":term")
+    let l:isVertical = l:splitDir == "v"
+    let l:splitCmd = (l:isVertical) ? "vsplit" : "split"
+    let l:resizeCmd = (l:isVertical) ? "vertical resize " : "resize "
     vsplit
-    vertical resize 150%
     wincmd w
+    exec "vertical resize " .(l:splitSize  * 2) ."%"
     exec "term " .s:sclangPipeApp
     wincmd w
   else

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -226,7 +226,7 @@ function SClangStart(...)
     let l:splitDir = (a:0 == 2) ? a:1 : s:scSplitDirection
     let l:splitSize = (a:0 == 2) ? a:2 : s:scSplitSize
 
-    if l:tmux
+    if l:tmuxclose
       let l:cmd = "tmux split-window -" . l:splitDir . " -p " . l:splitSize . " ;"
       let l:cmd .= "tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l"
       call system(l:cmd)
@@ -242,8 +242,14 @@ function SClangStart(...)
       call system("screen -S " . l:screenName . " -X bindkey -k k5")
     endif
 
-  else
-    call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
+  else "if has :term
+    vsplit
+    vertical resize 150%
+    wincmd w
+    term s:sclangPipeApp
+    wincmd w
+  "else
+    "call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
   endif
 
   let s:sclangStarted = 1

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -248,6 +248,7 @@ function SClangStart(...)
     wincmd w
     exec "vertical resize " .(l:splitSize  * 2) ."%"
     exec "term " .s:sclangPipeApp
+    exec "normal G"
     wincmd w
   else
     call system(s:sclangTerm . " " . s:sclangPipeApp . "&")

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -246,7 +246,7 @@ function SClangStart(...)
     vsplit
     vertical resize 150%
     wincmd w
-    term s:sclangPipeApp
+    exec 'term ' .s:sclangPipeApp
     wincmd w
   "else
     "call system(s:sclangTerm . " " . s:sclangPipeApp . "&")

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -219,6 +219,12 @@ endfunction
 
 let s:sclangStarted = 0
 
+function s:KillSClangBuffer()
+  if bufexists(bufname('start_pipe'))
+    exec 'bd! start_pipe'
+  endif
+endfunction
+
 function SClangStart(...)
   let l:tmux = exists('$TMUX')
   let l:screen = exists('$STY')
@@ -246,7 +252,7 @@ function SClangStart(...)
     let l:resizeCmd = (l:isVertical) ? "vertical resize " : "resize "
     vsplit
     wincmd w
-    exec "bd! start_pipe"
+    call s:KillSClangBuffer()
     exec "vertical resize " .(l:splitSize  * 2) ."%"
     exec "set wfw"
     exec "set wfh"
@@ -261,7 +267,7 @@ endfunction
 
 function SClangKill()
   call system(s:sclangDispatcher . " -q")
-  exec "bd! start_pipe"
+  call s:KillSClangBuffer()
 endfunction
 
 function SClangKillIfStarted()

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -247,6 +247,8 @@ function SClangStart(...)
     vsplit
     wincmd w
     exec "vertical resize " .(l:splitSize  * 2) ."%"
+    exec "set wfw"
+    exec "set wfh"
     exec "term " .s:sclangPipeApp
     exec "normal G"
     wincmd w

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -246,6 +246,7 @@ function SClangStart(...)
     let l:resizeCmd = (l:isVertical) ? "vertical resize " : "resize "
     vsplit
     wincmd w
+    exec "bd! start_pipe"
     exec "vertical resize " .(l:splitSize  * 2) ."%"
     exec "set wfw"
     exec "set wfh"
@@ -260,6 +261,7 @@ endfunction
 
 function SClangKill()
   call system(s:sclangDispatcher . " -q")
+  exec "bd! start_pipe"
 endfunction
 
 function SClangKillIfStarted()

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -78,6 +78,12 @@ if exists("g:scSplitSize")
   let s:scSplitSize = g:scSplitSize
 endif
 
+
+let s:scTerminalBuffer = "off"
+if exists("g:scTerminalBuffer")
+  let s:scTerminalBuffer = g:scTerminalBuffer
+endif
+
 " ========================================================================================
 
 function! FindOuterMostBlock()
@@ -219,6 +225,10 @@ endfunction
 
 let s:sclangStarted = 0
 
+function s:TerminalEnabled()
+  return exists(":term") && (s:scTerminalBuffer == "on")
+endfunction
+
 function s:KillSClangBuffer()
   if bufexists(bufname('start_pipe'))
     exec 'bd! start_pipe'
@@ -246,7 +256,7 @@ function SClangStart(...)
       call system("screen -S " . l:screenName . " -X resize " . l:splitSize . '%')
       call system("screen -S " . l:screenName . " -X bindkey -k k5")
     endif
-  elseif exists(":term")
+  elseif s:TerminalEnabled()
     let l:term = ":term "
     if !has("nvim")
       let l:term .= "++curwin ++close "

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -249,7 +249,7 @@ function SClangStart(...)
   elseif exists(":term")
     let l:term = ":term "
     if !has("nvim")
-      let l:term .= "++curwin "
+      let l:term .= "++curwin ++close "
     endif
     let l:isVertical = l:splitDir == "v"
     let l:splitCmd = (l:isVertical) ? "vsplit" : "split"
@@ -271,7 +271,9 @@ endfunction
 
 function SClangKill()
   call system(s:sclangDispatcher . " -q")
-  call s:KillSClangBuffer()
+    if has("nvim")
+      call s:KillSClangBuffer()
+  endif
 endfunction
 
 function SClangKillIfStarted()

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -240,23 +240,7 @@ function SClangStart(...)
   let l:screen = exists('$STY')
   let l:splitDir = (a:0 == 2) ? a:1 : s:scSplitDirection
   let l:splitSize = (a:0 == 2) ? a:2 : s:scSplitSize
-  if l:tmux || l:screen
-    if l:tmux
-      let l:cmd = "tmux split-window -" . l:splitDir . " -p " . l:splitSize . " ;"
-      let l:cmd .= "tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l"
-      call system(l:cmd)
-    elseif l:screen
-      " Main window will have focus when splitting, so recalculate splitSize percentage
-      let l:splitSize = 100 - l:splitSize
-      let l:splitDir = (l:splitDir == "v") ? "" : " -v"
-      let l:screenName = system("echo -n $STY")
-      call system("screen -S " . l:screenName . " -X split" . l:splitDir)
-      call system("screen -S " . l:screenName . " -X eval focus screen focus")
-      call system("screen -S " . l:screenName . " -X at 1# exec " . s:sclangPipeApp)
-      call system("screen -S " . l:screenName . " -X resize " . l:splitSize . '%')
-      call system("screen -S " . l:screenName . " -X bindkey -k k5")
-    endif
-  elseif s:TerminalEnabled()
+  if s:TerminalEnabled()
     let l:term = ":term "
     if !has("nvim")
       let l:term .= "++curwin ++close "
@@ -273,6 +257,22 @@ function SClangStart(...)
     exec l:term .s:sclangPipeApp
     exec "normal G"
     wincmd w
+  elseif l:tmux || l:screen
+    if l:tmux
+      let l:cmd = "tmux split-window -" . l:splitDir . " -p " . l:splitSize . " ;"
+      let l:cmd .= "tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l"
+      call system(l:cmd)
+    elseif l:screen
+      " Main window will have focus when splitting, so recalculate splitSize percentage
+      let l:splitSize = 100 - l:splitSize
+      let l:splitDir = (l:splitDir == "v") ? "" : " -v"
+      let l:screenName = system("echo -n $STY")
+      call system("screen -S " . l:screenName . " -X split" . l:splitDir)
+      call system("screen -S " . l:screenName . " -X eval focus screen focus")
+      call system("screen -S " . l:screenName . " -X at 1# exec " . s:sclangPipeApp)
+      call system("screen -S " . l:screenName . " -X resize " . l:splitSize . '%')
+      call system("screen -S " . l:screenName . " -X bindkey -k k5")
+    endif
   else
     call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
   endif

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -241,17 +241,15 @@ function SClangStart(...)
       call system("screen -S " . l:screenName . " -X resize " . l:splitSize . '%')
       call system("screen -S " . l:screenName . " -X bindkey -k k5")
     endif
-
-  else "if has :term
+  elseif exists(":term")
     vsplit
     vertical resize 150%
     wincmd w
-    exec 'term ' .s:sclangPipeApp
+    exec "term " .s:sclangPipeApp
     wincmd w
-  "else
-    "call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
+  else
+    call system(s:sclangTerm . " " . s:sclangPipeApp . "&")
   endif
-
   let s:sclangStarted = 1
 endfunction
 

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -226,7 +226,7 @@ function SClangStart(...)
     let l:splitDir = (a:0 == 2) ? a:1 : s:scSplitDirection
     let l:splitSize = (a:0 == 2) ? a:2 : s:scSplitSize
 
-    if l:tmuxclose
+    if l:tmux
       let l:cmd = "tmux split-window -" . l:splitDir . " -p " . l:splitSize . " ;"
       let l:cmd .= "tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l"
       call system(l:cmd)

--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -247,6 +247,10 @@ function SClangStart(...)
       call system("screen -S " . l:screenName . " -X bindkey -k k5")
     endif
   elseif exists(":term")
+    let l:term = ":term "
+    if !has("nvim")
+      let l:term .= "++curwin "
+    endif
     let l:isVertical = l:splitDir == "v"
     let l:splitCmd = (l:isVertical) ? "vsplit" : "split"
     let l:resizeCmd = (l:isVertical) ? "vertical resize " : "resize "
@@ -256,7 +260,7 @@ function SClangStart(...)
     exec "vertical resize " .(l:splitSize  * 2) ."%"
     exec "set wfw"
     exec "set wfh"
-    exec "term " .s:sclangPipeApp
+    exec l:term .s:sclangPipeApp
     exec "normal G"
     wincmd w
   else


### PR DESCRIPTION
This PR adds the functionality requested on #37.
If opened inside tmux or screen or if vim does not have the `:term` command,
it defaults to the old behaviour