### PR TITLE
prefer bin path one up from SCVim.sc

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -246,12 +246,14 @@ function SClangStart(...)
       let l:term .= "++curwin ++close "
     endif
     let l:isVertical = l:splitDir == "v"
-    let l:splitCmd = (l:isVertical) ? "vsplit" : "split"
-    let l:resizeCmd = (l:isVertical) ? "vertical resize " : "resize "
-    vsplit
+    exec (l:isVertical) ? "vsplit" : "split"
     wincmd w
     call s:KillSClangBuffer()
-    exec "vertical resize " .(l:splitSize  * 2) ."%"
+    if l:isVertical
+      exec "vertical resize " .(l:splitSize * 2)
+    else
+      exec "resize " .(l:splitSize)
+    end
     exec "set wfw"
     exec "set wfh"
     exec l:term .s:sclangPipeApp

--- a/sc/SCVim.sc
+++ b/sc/SCVim.sc
@@ -42,33 +42,44 @@ SCVim {
 		};
 
 		StartUp.add {
-			var classList, file, hugeString = "syn keyword scObject", basePath;
+			var classList, file, hugeString = "syn keyword scObject", basePath, binPath, ftpluginPath;
 
-			// search in vim's standard 'pack' directories
-			PathName("~/.vim/pack/*/*/".standardizePath).folders.do{ |folder|
-				if(folder.fullPath.contains("scvim")) {
-					basePath = folder.fullPath;
-				};
-			};
+			// see if this file in the 'scvim' directory, prefer that
+			basePath = PathName(this.class.filenameSymbol.asString.dirname) +/+ PathName("..");
 
-			// search two folders deep below ~/.vim for a folder named "*scvim*"
-			if(basePath.isNil) {
-				PathName("~/.vim".standardizePath).folders.do{ |folder|
+			binPath = basePath +/+ PathName("bin/");
+			ftpluginPath = basePath +/+ PathName("ftplugin/");
+
+			if(File.exists(binPath.fullPath) && File.exists(ftpluginPath.fullPath)) {
+				basePath = basePath.fullPath;
+			} {
+				basePath = nil;
+				// search in vim's standard 'pack' directories
+				PathName("~/.vim/pack/*/*/".standardizePath).folders.do{ |folder|
 					if(folder.fullPath.contains("scvim")) {
 						basePath = folder.fullPath;
-					} {
-						folder.folders.do{ |subfolder|
-							if(subfolder.fullPath.contains("scvim")) {
-								basePath = subfolder.fullPath;
+					};
+				};
+
+				// search two folders deep below ~/.vim for a folder named "*scvim*"
+				if(basePath.isNil) {
+					PathName("~/.vim".standardizePath).folders.do{ |folder|
+						if(folder.fullPath.contains("scvim")) {
+							basePath = folder.fullPath;
+						} {
+							folder.folders.do{ |subfolder|
+								if(subfolder.fullPath.contains("scvim")) {
+									basePath = subfolder.fullPath;
+								}
 							}
-						}
+						};
 					};
 				};
 			};
 
 			if(basePath.isNil) {
 				("\nSCVim could not be initialized.\n"
-				++ "Consult the README to see how to install scvim.\n").error
+					++ "Consult the README to see how to install scvim.\n").error
 			} {
 				//collect all class names as strings in a Array
 				classList = Object.allSubclasses.collect{ arg i; var name;
@@ -79,7 +90,7 @@ SCVim {
 				file = File((basePath ++ "/syntax/supercollider_objects.vim").standardizePath,"w");
 				file.write(hugeString);
 				file.close;
-			}
+			};
 		};
 	}
 

--- a/sc/SCVim.sc
+++ b/sc/SCVim.sc
@@ -45,7 +45,7 @@ SCVim {
 			var classList, file, hugeString = "syn keyword scObject", basePath, binPath, ftpluginPath;
 
 			// see if this file in the 'scvim' directory, prefer that
-			basePath = PathName(this.class.filenameSymbol.asString.dirname) +/+ PathName("..");
+			basePath = PathName(this.class.filenameSymbol.asString.dirname) +/+ "..";
 
 			binPath = basePath +/+ PathName("bin/");
 			ftpluginPath = basePath +/+ PathName("ftplugin/");


### PR DESCRIPTION
I'm certainly not an expert in the SC language so I'm open to pointers here.

The scvim help docs now indicate: `It is highly recommended to use either Vim 8+'s native packages or a plugin manager to install scvim.` It seems to me that it would also be recommended to point supercollider at the `SCVim.sc` in installed there.

This work makes the `binPath` search prefer the directory just above `SCVim.sc`.

An added side effect is that it makes scvim work with neovim with vim-plugged installed packages. (Which is what I'm using these days).