### PR TITLE
fix(SClangStart): Update tmux split-window command

### DIFF
--- a/ftplugin/supercollider.vim
+++ b/ftplugin/supercollider.vim
@@ -259,7 +259,7 @@ function SClangStart(...)
     wincmd w
   elseif l:tmux || l:screen
     if l:tmux
-      let l:cmd = "tmux split-window -" . l:splitDir . " -p " . l:splitSize . " ;"
+      let l:cmd = "tmux split-window -" . l:splitDir . " -l " . l:splitSize . "% ; "
       let l:cmd .= "tmux send-keys " . s:sclangPipeApp . " Enter ; tmux select-pane -l"
       call system(l:cmd)
     elseif l:screen


### PR DESCRIPTION
The -p flag is deprecated since tmux 3.1 (Feb 4, 2020) and is broken in tmux 3.4 although the main branch already has a fix for it. Nevertheless we should move to the new syntax as -p *will* be dropped at some point.